### PR TITLE
Fixes use of gatsby-plugin-page-progress

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,8 +21,8 @@ module.exports = {
     {
       resolve: `gatsby-plugin-page-progress`,
       options: {
-        includePath: [{ regex: "^/blog" }],
-        excludePath: [{ regex: "^/pages" }],
+        includePaths: [{ regex: "^/blog" }],
+        excludePaths: ["/about", "/now"],
         height: 4,
         prependToBody: true,
         color: `#226597`,


### PR DESCRIPTION
Hey Kien! 👋🏻

Had a quick look a your repo here and it looks like `includePaths` and `excludePaths` (with an `s`) were not spelled correctly. I know that you were also looking to exclude the progress bar from the `about` and `now` pages, and I've done that in this PR like so:

```
excludePaths: ["/about", "/now"],
```

The reason that I've done it this way as apposed to using the regex syntax is because it looks to me like you're trying to exclude *specific* paths. The regex syntax is for more dynamic paths, and an example of that would be:

```
excludePaths: [{ regex: "^/posts" }],
```

☝️ In the code above, what I'm saying is any path that starts with `/posts` should be excluded from having a progress bar. That would include any and all routes that begin with `/posts`:

- /posts/beep/
- /posts/beep/beep/
- /posts/beep/beep/lettuce/

It would match all routes nested underneath it. In fact, that regex would also match `/postsssssssss`.

I hope that this PR and my explanation clears up the usage of the plugin a little better. Happy coding 🚀